### PR TITLE
Prefer `border: 0` over `border: none`

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -2,7 +2,7 @@ linters:
 
   BorderZero:
     enabled: true
-    convention: none
+    convention: zero
 
   BemDepth:
     enabled: true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     - [OOCSS and BEM](#oocss-and-bem)
     - [ID Selectors](#id-selectors)
     - [JavaScript hooks](#javascript-hooks)
+    - [Border](#border)
   1. [Sass](#sass)
     - [Syntax](#syntax)
     - [Ordering](#ordering-of-property-declarations)
@@ -167,6 +168,26 @@ We recommend creating JavaScript-specific classes to bind to, prefixed with `.js
 
 ```html
 <button class="btn btn-primary js-request-to-book">Request to Book</button>
+```
+
+### Border
+
+Use `0` instead of `none` to specify that a style has no border.
+
+**Bad**
+
+```css
+.foo {
+  border: none;
+}
+```
+
+**Good**
+
+```css
+.foo {
+  border: 0;
+}
 ```
 
 ## Sass


### PR DESCRIPTION
Although the scss-lint configuration file here enforced `border: none`,
we chatted about it and agreed that we prefer `border: 0`.