### PR TITLE
Default scss-lint severity to error

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,3 +1,5 @@
+severity: error
+
 linters:
 
   BorderZero:


### PR DESCRIPTION
scss-lint 0.44.0 added a global severity configuration setting. Since
warnings are often ignored, we want to set this to error by default.