### PR TITLE
Add link to license in readme TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Extend directive](#extend-directive)
     - [Nested selectors](#nested-selectors)
 1. [Translation](#translation)
+1. [License](#license)
 
 ## Terminology
 


### PR DESCRIPTION
Forgot to add a Table of Contents link to the readme - this adds it in.

@lencioni 